### PR TITLE
Remove Yotter for Youtube because it's archived and no longer maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,6 @@ Overview of alternative open source front-ends for popular internet platforms (e
 
 - [yt-dlp](https://github.com/yt-dlp/yt-dlp): A youtube-dl fork with additional features and fixes
 
-- [Yotter](https://github.com/ytorg/Yotter): Youtube and Twitter with privacy
-  - [Yotter instances](https://github.com/ytorg/Yotter#public-instances)
-  - Official instance: [yotter.xyz](https://yotter.xyz)
-
 - [uYouPlus](https://github.com/qnblackcat/uYouPlus): uYouPlus (uYou+) is an alternative YouTube app for Apple's iOS and iPadOS
 
 - [SmartTubeNext](https://github.com/yuliskov/SmartTubeNext): SmartTubeNext is an advanced YouTube app for Android TVs and TV boxes, free and open source. It is not a live TV client and does not support "YouTube TV"


### PR DESCRIPTION
I have removed Yotter as an alternative for Youtube because this project is archived and will not be developed anymore.

In the README Yotter says to use Piped instead. See [here](https://github.com/ytorg/Yotter) for further information.