### PR TITLE
Fritter for Twitter: Remove mention of iOS client because it doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Overview of alternative open source front-ends for popular internet platforms (e
 
 - [Tweepy](https://github.com/tweepy/tweepy): Twitter for Python
 
-- [Fritter](https://github.com/jonjomckay/fritter): A free, open-source Twitter client for Android and iOS
+- [Fritter](https://github.com/jonjomckay/fritter): A free, open-source Twitter client for Android
 
 ### Reddit
 


### PR DESCRIPTION
There is no iOS client for Fritter as seen on https://fritter.cc/ or https://github.com/jonjomckay/fritter

(Which is quite unfortunate as I was looking for an iOS app front-end...)