### PR TITLE
Remove link to bibliogram repo on Github

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,6 @@ Overview of alternative open source front-ends for popular internet platforms (e
   - Official instance: [https://bibliogram.art](https://bibliogram.art)
   - Public instances: https://git.sr.ht/~cadence/bibliogram-docs/tree/master/docs/Instances.md
   - Example: Troy Hunt on [Instagram](https://www.instagram.com/troyhunt) and [Bibliogram](https://bibliogram.art/u/troyhunt)
-  - Originally hosted on [Github](https://github.com/cloudrac3r/bibliogram)
 
 - [Barinsta](https://github.com/austinhuang0131/barinsta): Open-source alternative Instagram client for Android
   - On July 26, 2021, Austin Huang (maintainer of Barinsta) received a cease & desist letter from Perkins Coie LLP, a law firm representing Facebook. As a result, Barinsta is no longer maintained or distributed. More information can be found at https://github.com/mendel5/alternative-front-ends/issues/28 and https://austinhuang.me/barinsta .


### PR DESCRIPTION
I removed the link for the source repository from bibliogram as the site is not available anymore.