### PR TITLE
Remove Outline.com because the service is not available anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,9 +409,6 @@ Overview of alternative open source front-ends for popular internet platforms (e
 
 - [Pluja's Awesome Privacy](https://github.com/pluja/awesome-privacy): A curated list of services and alternatives that respect your privacy because privacy matters.
 
-- [Outline.com](https://outline.com): Outline is a free service for reading and annotating news articles.
-  - Note: The source code of Outline.com is not available under a free/open-source license.
-
 - [Youtube Vanced](https://github.com/YTVanced): Youtube replacement app for the Android platform: YouTube Vanced is the stock Android YouTube app, but better. It includes adblocking, true amoled dark mode and a lot more. Use the Vanced Manager to install YouTube Vanced with ease.
   - Official website with install instructions: https://vancedapp.com
   - Note: The source code of Youtube Vanced is not available under a free/open-source license.


### PR DESCRIPTION
it's not available anymore, looks like the domain expired.