### PR TITLE
More alternatives and update

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Overview of open-source alternative for popular applications.
 - [Shazam](#shazam)
 - [Hacker News](#hacker-news)
 - [Quora](#quora)
+- [Pastebin](#pastebin)
 - [Other services](#other-services)
 - [Redirection](#redirection)
 - [Related projects](#related-projects)
@@ -434,6 +435,8 @@ Overview of open-source alternative for popular applications.
 
  - [Keepass2Android](https://github.com/PhilippC/keepass2android): A Password manager app for Android. Requires no internet connection.
 
+ - [vaultwarden](https://github.com/dani-garcia/vaultwarden): Password manager. Unofficial Bitwarden compatible server written in Rust, formerly known as bitwarden_rs
+
 ### Nova Launcher
 
 - [Neo Launcher](https://github.com/NeoApplications/Neo-Launcher): A fork of AOSP's launcher for power-users.
@@ -475,6 +478,12 @@ Overview of open-source alternative for popular applications.
   - Official instance: https://quetre.iket.me
   - List of instances: https://github.com/zyachel/quetre#instances
 
+## Pastebin
+
+- [NoPaste](https://github.com/bokub/nopaste): NoPaste is an open-source website similar to Pastebin where you can store any piece of code, and generate links for easy sharing
+
+- [PrivateBin](https://github.com/PrivateBin/PrivateBin): Zero knowledge encrypted paste-bin. A minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted in the browser using 256 bits AES
+
 ### Hacker News
 
 - [HN-search](https://github.com/algolia/hn-search): Algolia Hacker News search
@@ -497,12 +506,6 @@ Overview of open-source alternative for popular applications.
 - [MediathekViewWeb](https://github.com/mediathekview/mediathekviewweb): Video content of German public-service television broadcasters (e.g. ARD, ZDF)
   - Official instance: [mediathekviewweb.de](https://mediathekviewweb.de)
 
-- [NoPaste](https://github.com/bokub/nopaste): NoPaste is an open-source website similar to Pastebin where you can store any piece of code, and generate links for easy sharing
-
-- [PrivateBin](https://github.com/PrivateBin/PrivateBin): Zero knowledge encrypted paste-bin. A minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted in the browser using 256 bits AES
-
-- [vaultwarden](https://github.com/dani-garcia/vaultwarden): Password manager. Unofficial Bitwarden compatible server written in Rust, formerly known as bitwarden_rs
-
 - [snapdrop](https://github.com/RobinLinus/snapdrop): Similar to Apple's Airdrop but in your browser. A Progressive Web App for local file sharing
 
 - [hedgedoc](https://github.com/hedgedoc/hedgedoc): Collaborative markdown editor. A platform to write and share markdown
@@ -512,8 +515,6 @@ Overview of open-source alternative for popular applications.
 - [gitea](https://github.com/go-gitea/gitea): Lightweight git server. Git with a cup of tea, painless self-hosted git service
 
 - [ArchiveBox](https://github.com/ArchiveBox/ArchiveBox): Open source self-hosted web archiving. Takes URLs/browser history/bookmarks/Pocket/Pinboard/etc., saves HTML, JS, PDFs, media, and more
-
-- [Wikiless](https://codeberg.org/orenom/wikiless): A free open source alternative Wikipedia front-end focused on privacy
 
 - [Librarian](https://codeberg.org/librarian/librarian): Alternative frontend for LBRY / Odysee.com
   - Official instance: https://librarian.bcow.xyz

--- a/README.md
+++ b/README.md
@@ -518,6 +518,9 @@ Overview of open-source alternative for popular applications.
 - [Elk](https://github.com/elk-zone): A nimble Mastodon web client made by core Vue, Tauri, and Nuxt developers.
   - Website: https://elk.zone/mas.to/public
 
+- [Brutaldon](https://gitlab.com/brutaldon/brutaldon): A brutalist, Web 1.0 web interface for Mastodon and Pleroma. Works completely without JavaScript.
+  - Website: https://brutaldon.org/
+  
 #### Mobile
 
 - [Tusky](https://github.com/tuskyapp/Tusky): lightweight Android Mastodon client

--- a/README.md
+++ b/README.md
@@ -284,6 +284,10 @@ Overview of open-source alternative for popular applications.
 
 - [Spytify](https://github.com/jwallet/spy-spotify): A Spotify recorder for Windows which records Spotify audio without recording or playing ads, ensuring no loss in sound quality.
 
+- [Spicetify](https://github.com/spicetify/spicetify-cli): Command-line tool to customize the official Spotify client. Supports Windows, MacOS and Linux.
+
+
+
 #### Mobile
 
 - [Spotube](https://github.com/KRTirtho/spotube): a Flutter based lightweight spotify client. It utilizes the power of Spotify & Youtube's public API & creates a hazardless, performant & resource friendly User Experience
@@ -506,8 +510,13 @@ Overview of open-source alternative for popular applications.
 #### Web
 
 - [Pinafore](https://github.com/nolanlawson/pinafore): Alternative web client for Mastodon, focused on speed and simplicity
+  - Website: https://pinafore.social/
 
 - [Cuckoo+](https://github.com/NanaMorse/Cuckoo.Plus): A GooglePlus-Like third-party web client for mastodon.
+  - Website: https://www.cuckoo.social/
+  
+- [Elk](https://github.com/elk-zone): A nimble Mastodon web client made by core Vue, Tauri, and Nuxt developers.
+  - Website: https://elk.zone/mas.to/public
 
 #### Mobile
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ Overview of open-source alternative for popular applications.
 
 - [ytcast](https://github.com/MarcoLucidi01/ytcast): Cast YouTube videos to your smart TV from the command line. This program does roughly the same thing as the "Play on TV" button that appears on the player bar when you visit youtube.com with Chrome or when you use the YouTube smartphone app
 
-
 ### YouTube Music
 
 #### Desktop
@@ -142,6 +141,9 @@ Overview of open-source alternative for popular applications.
 #### Web
 
 - [Beatbump](https://github.com/snuffyDev/Beatbump): An alternative frontend for YouTube Music created using Svelte/SvelteKit, powered by Cloudflare Workers
+
+- [Brianify](https://github.com/herbievine/brian-ify): A simple Youtube to mp3 downloader
+  -  Website: https://brianify.herbievine.com/
 
 #### Mobile
 
@@ -276,6 +278,8 @@ Overview of open-source alternative for popular applications.
 - [librespot](https://github.com/librespot-org/librespot): Requires Spotify Premium Account - librespot is an open source client library for Spotify. It enables applications to use Spotify's service to control and play music via various backends, and to act as a Spotify Connect receiver. It is an alternative to the official and now deprecated closed-source libspotify. Additionally, it will provide extra features which are not available in the official library
 
 - [oggify](https://github.com/pisto/oggify): Download Spotify tracks to Ogg Vorbis (with a Spotify premium account), based on librespot
+
+- [Spytify](https://github.com/jwallet/spy-spotify): A Spotify recorder for Windows which records Spotify audio without recording or playing ads, ensuring no loss in sound quality.
 
 #### Mobile
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Overview of open-source alternative for popular applications.
 
 ### YouTube
 
+#### Web
+
 - [Invidious](https://github.com/iv-org/invidious): Invidious is an alternative front-end to YouTube - Lightweight, no ads, no tracking, no JavaScript required
   - Home page: https://invidious.io
   - Invidious instances: https://github.com/iv-org/documentation/blob/master/docs/instances.md
@@ -57,60 +59,38 @@ Overview of open-source alternative for popular applications.
   - Official instance: [https://tube.cadence.moe](https://tube.cadence.moe)
   - Installation guide for self-hosting: https://git.sr.ht/~cadence/tube-docs/tree/main/item/docs/cloudtube/Installing%20CloudTube.md
 
-- [YouTube.js](https://github.com/LuanRT/YouTube.js): Full-featured wrapper around the Innertube API, which is what YouTube itself uses
-
-- [FreeTube](https://github.com/FreeTubeApp/FreeTube): Open source YouTube desktop player for privacy on Windows, Mac and Linux
-
 - [Invuedious](https://github.com/bocchilorenzo/invuedious): An alternative frontend for invidious built with vue.js
   - Official instance: [https://bocchilorenzo.github.io/invuedious/](https://bocchilorenzo.github.io/invuedious)
-
-- [Youtube-viewer](https://github.com/trizen/youtube-viewer): Lightweight YouTube client for Linux
-
-- [pipe-viewer](https://github.com/trizen/pipe-viewer): A lightweight application (fork of straw-viewer) for searching and playing videos from YouTube.
-
-- [Invidious-viewer](https://github.com/git-bruh/invidious-viewer): Python application to watch YouTube videos through the Invidious API, in the terminal (requires MPV player and libmpv.so, provided by Linux distro)
-
-- [NewPipe](https://github.com/TeamNewPipe/NewPipe): A libre lightweight streaming front-end for Android
-
-- [NewPipe with SponsorBlock & Return YouTube Dislike](https://github.com/polymorphicshade/NewPipe): A fork of NewPipe with SponsorBlock and Return YouTube Dislike functionality.
-
-- [Youtube-dl](https://github.com/ytdl-org/youtube-dl): Command-line program to download videos from YouTube.com and other video sites
-
-- [OpenVideoDownloader aka jely2002/youtube-dl-gui](https://github.com/jely2002/youtube-dl-gui): A cross-platform GUI for youtube-dl made in Electron and node.js
-
-- [ytdl-gui](https://github.com/JaGoLi/ytdl-gui): A simple-to-use, cross-platform graphical interface for youtube-dl
-
-- [Alltube](https://github.com/Rudloff/alltube): Web GUI for youtube-dl
-
-- [Vividl](https://github.com/Bluegrams/Vividl): Modern Windows GUI for youtube-dl
-
-- [Tartube](https://github.com/axcore/tartube): A GUI front-end for youtube-dl, partly based on youtube-dl-gui and written in Python 3 / Gtk 3
-
-- [ytmdl](https://github.com/deepjyoti30/ytmdl): A simple app to get songs from YouTube in mp3 format with artist name, album name etc from sources like iTunes, LastFM, Deezer, Gaana etc.
-
-- [Plumber](https://github.com/keshavbhatt/plumber): Local and remote video trimmer, can trim parts of video without downloading whole video, utilizes youtube-dl, allows conversion to GIFs
-
-- [ViewTube](https://github.com/ViewTube/viewtube-vue): An alternative front-end for YouTube, written in Vue.js, uses Plyr video player; supports SponsorBlock, multiple Invidious instances support, chapters
 
 - [youtube-local](https://github.com/user234683/youtube-local): Browser-based client for watching Youtube anonymously and with greater page performance
 
 - [yt-local](https://git.sr.ht/~heckyel/yt-local): Browser-based client for watching Youtube anonymously without forcing javascript (Fork of [youtube-local](https://github.com/user234683/youtube-local))
 
-- [SkyTube](https://github.com/SkyTubeTeam/SkyTube): An open-source YouTube app for Android
+- [pipe-viewer](https://github.com/trizen/pipe-viewer): A lightweight application (fork of straw-viewer) for searching and playing videos from YouTube.
+
+- [Alltube](https://github.com/Rudloff/alltube): Web GUI for youtube-dl
+
+- [ytmdl](https://github.com/deepjyoti30/ytmdl): A simple app to get songs from YouTube in mp3 format with artist name, album name etc from sources like iTunes, LastFM, Deezer, Gaana etc.
+
+- [ViewTube](https://github.com/ViewTube/viewtube-vue): An alternative front-end for YouTube, written in Vue.js, uses Plyr video player; supports SponsorBlock, multiple Invidious instances support, chapters
+
+#### Desktop
+
+- [Youtube-dl](https://github.com/ytdl-org/youtube-dl): Command-line program to download videos from YouTube.com and other video sites
+
+- [OpenVideoDownloader aka jely2002/youtube-dl-gui](https://github.com/jely2002/youtube-dl-gui): A cross-platform GUI for youtube-dl made in Electron and node.js
 
 - [yt-dlp](https://github.com/yt-dlp/yt-dlp): A youtube-dl fork with additional features and fixes
 
-- [uYouPlus](https://github.com/qnblackcat/uYouPlus): uYouPlus (uYou+) is an alternative YouTube app for Apple's iOS and iPadOS
+- [Vividl](https://github.com/Bluegrams/Vividl): Modern Windows GUI for youtube-dl
 
-- [SmartTubeNext](https://github.com/yuliskov/SmartTubeNext): SmartTubeNext is an advanced YouTube app for Android TVs and TV boxes, free and open source. It is not a live TV client and does not support "YouTube TV"
+- [Tartube](https://github.com/axcore/tartube): A GUI front-end for youtube-dl, partly based on youtube-dl-gui and written in Python 3 / Gtk 3
 
-- [TubeSync](https://github.com/meeb/tubesync): TubeSync is a PVR (personal video recorder) for YouTube. It syncs YouTube channels and playlists to a locally hosted media server
+- [FreeTube](https://github.com/FreeTubeApp/FreeTube): Open source YouTube desktop player for privacy on Windows, Mac and Linux
 
-- [TubeArchivist](https://github.com/bbilly1/tubearchivist): A self hosted YouTube media server
+- [Youtube-viewer](https://github.com/trizen/youtube-viewer): Lightweight YouTube client for Linux
 
-- [ytfzf](https://github.com/pystardust/ytfzf): A POSIX script that helps you find Youtube videos (without API) and opens/downloads them using mpv/youtube-dl
-
-- [ytcc](https://github.com/woefe/ytcc): Command line tool to keep track of your favorite playlists on YouTube and many other places. Can import youtube subscriptions from Google Takeout and provide them as an RSS feed for your favorite reader
+- [minitube](https://github.com/flaviotordini/minitube): Lightweight youtube client with a kid-friendly interface. Can make playlists from search keywords
 
 - [smtube](https://github.com/smplayer-dev/smtube): Stand-alone YouTube video player
   - Website: https://www.smtube.org
@@ -118,13 +98,15 @@ Overview of open-source alternative for popular applications.
   - SMPlayer website: https://www.smplayer.info
   - SMPlayer repository: https://github.com/smplayer-dev/smplayer
 
-- [mps-youtube](https://github.com/mps-youtube/mps-youtube): Terminal based YouTube player and downloader
+- [ytcc](https://github.com/woefe/ytcc): Command line tool to keep track of your favorite playlists on YouTube and many other places. Can import youtube subscriptions from Google Takeout and provide them as an RSS feed for your favorite reader
 
-- [minitube](https://github.com/flaviotordini/minitube): Lightweight youtube client with a kid-friendly interface. Can make playlists from search keywords
+- [ytfzf](https://github.com/pystardust/ytfzf): A POSIX script that helps you find Youtube videos (without API) and opens/downloads them using mpv/youtube-dl
 
-- [yattee](https://github.com/yattee/yattee): Alternative YouTube frontend for iOS, tvOS and macOS built with Invidious and Piped, supports sponsorblock
+#### Mobile
 
-- [ytcast](https://github.com/MarcoLucidi01/ytcast): Cast YouTube videos to your smart TV from the command line. This program does roughly the same thing as the "Play on TV" button that appears on the player bar when you visit youtube.com with Chrome or when you use the YouTube smartphone app
+- [NewPipe](https://github.com/TeamNewPipe/NewPipe): A libre lightweight streaming front-end for Android
+
+- [NewPipe with SponsorBlock & Return YouTube Dislike](https://github.com/polymorphicshade/NewPipe): A fork of NewPipe with SponsorBlock and Return YouTube Dislike functionality.
 
 - [LibreTube](https://github.com/libre-tube/LibreTube): Android frontend for YouTube, based on Piped
 
@@ -132,7 +114,20 @@ Overview of open-source alternative for popular applications.
 
 - [VueTube](https://github.com/VueTubeApp/VueTube): A simple and open source video streaming client aimed to recreate ALL the features from their respective apps. Built on Vue
 
-- [Hyperion](https://github.com/zt64/Hyperion): A modern alternate YouTube front-end for Android
+- [Hyperion](https://github.com/zt64/Hyperion): A modern alternate YouTube front-end for Android/
+
+- [SkyTube](https://github.com/SkyTubeTeam/SkyTube): An open-source YouTube app for Android
+
+- [uYouPlus](https://github.com/qnblackcat/uYouPlus): uYouPlus (uYou+) is an alternative YouTube app for Apple's iOS and iPadOS
+
+#### TV
+
+- [SmartTubeNext](https://github.com/yuliskov/SmartTubeNext): SmartTubeNext is an advanced YouTube app for Android TVs and TV boxes, free and open source. It is not a live TV client and does not support "YouTube TV"
+
+- [yattee](https://github.com/yattee/yattee): Alternative YouTube frontend for iOS, tvOS and macOS built with Invidious and Piped, supports sponsorblock
+
+- [ytcast](https://github.com/MarcoLucidi01/ytcast): Cast YouTube videos to your smart TV from the command line. This program does roughly the same thing as the "Play on TV" button that appears on the player bar when you visit youtube.com with Chrome or when you use the YouTube smartphone app
+
 
 ### YouTube Music
 
@@ -388,7 +383,14 @@ Overview of open-source alternative for popular applications.
 
 ### Google Translate
 
+#### Desktop
+
+- [Crow Translate](https://github.com/crow-translate/crow-translate): Simple and lightweight cross-platform translator that allows translation using LibreTranslate, Lingva, Google, Bing, and Yandex, as well as text-to-speech using Google
+
 #### Web
+
+- [LibreTranslate](https://github.com/LibreTranslate/LibreTranslate): Free and Open Source Machine Translation API. 100% self-hosted, offline capable and easy to setup.
+  - Official instance: https://libretranslate.com/
 
 - [Lingva Translate](https://github.com/TheDavidDelta/lingva-translate): Alternative front-end for Google Translate, serving as a free and open-source translator with over a hundred languages available
   - Official instance: [lingva.ml](https://lingva.ml)
@@ -398,18 +400,20 @@ Overview of open-source alternative for popular applications.
   - Official instance: [simplytranslate.org](https://simplytranslate.org)
   - Home page and public instances: https://simple-web.org/projects/simplytranslate.html
 
+#### Mobile
+
+- [DeepL Android](https://github.com/sakusaku3939/DeepLAndroid): Unofficial Android client for DeepL
+  - Available on [F-Droid](https://f-droid.org/en/packages/com.example.deeplviewer)
+
 - [SimplyTranslate Mobile](https://github.com/ManeraKai/simplytranslate_mobile): Unofficial Android client of SimplyTranslate.
   - Available on [F-Droid](https://f-droid.org/en/packages/com.simplytranslate_mobile)
 
 - [InstaLate](https://gitlab.com/concept1tech/instalate): Distraction-free translation for Android, to be used directly from within any app. Supports Beolingus, DeepL, Dict.cc, GNU CIDE, Heinzelnisse, LibreTranslate, Linguee, WikDict and Wiktionary.
   - Available on [F-Droid](https://f-droid.org/en/packages/com.concept1tech.instalate)
 
-- [DeepL Android](https://github.com/sakusaku3939/DeepLAndroid): Unofficial Android client for DeepL
-  - Available on [F-Droid](https://f-droid.org/en/packages/com.example.deeplviewer)
-
-- [Crow Translate](https://github.com/crow-translate/crow-translate): Simple and lightweight cross-platform translator that allows translation using LibreTranslate, Lingva, Google, Bing, and Yandex, as well as text-to-speech using Google
-
 ### Google Play Store
+
+#### Mobile
 
 - [Aurora Store](https://gitlab.com/AuroraOSS/AuroraStore): An Open Source alternative for Google Play Store
 
@@ -420,13 +424,19 @@ Overview of open-source alternative for popular applications.
 
 ### Google Authenticator
 
+#### Mobile
+
 - [Aegis](https://github.com/beemdevelopment/Aegis): A free, secure and open source app for Android to manage your 2-step verification tokens.
 
 - [Authenticator Pro](https://github.com/jamie-mh/AuthenticatorPro): Two-Factor Authentication (2FA) client for Android + Wear OS
 
 ### Google Maps
 
+#### Web
+
 - [OpenStreetMap](https://www.openstreetmap.org/): built by a community of mappers that contribute and maintain data about roads, trails, cafés, railway stations, and much more, all over the world.
+
+#### Mobile
 
 - [StreetComplete](https://github.com/streetcomplete/StreetComplete): Easy to use OpenStreetMap editor for Android.
 
@@ -434,13 +444,21 @@ Overview of open-source alternative for popular applications.
 
 ### Gmail
 
+#### Desktop
+
 - [Thunderbird](https://www.thunderbird.net/en-US/): A free open-source cross-platform email client.
+
+- [Mailspring](https://github.com/Foundry376/Mailspring): A beautiful, fast and fully open source mail client for Mac, Windows and Linux.
+
+#### Mobile
 
 - [FairEmail](https://github.com/M66B/FairEmail): Fully featured, open source, privacy friendly email app for Android
 
 - [K-9 Mail](https://github.com/thundernest/k-9): an open-source email client for Android
 
 ### Gboard
+
+#### Mobile
 
 - [OpenBoard](https://github.com/openboard-team/openboard): 100% FOSS keyboard based on AOSP, with no dependency on Google binaries, that respects your privacy.
 
@@ -450,19 +468,21 @@ Overview of open-source alternative for popular applications.
 
 ### Facebook
 
+#### Mobile
+
 - [Frost](https://github.com/AllanWang/Frost-for-Facebook): An extensive and functional third party app for Facebook (Android app)
 
 ### Facebook Messenger
+
+#### Desktop
 
 - [Caprine](https://github.com/sindresorhus/caprine): Unofficial and privacy-focused Facebook Messenger app with many useful features
 
 ### Mastodon
 
-- [Pinafore](https://github.com/nolanlawson/pinafore): Alternative web client for Mastodon, focused on speed and simplicity
+#### Desktop
 
-- [Cuckoo+](https://github.com/NanaMorse/Cuckoo.Plus): A GooglePlus-Like third-party web client for mastodon.
-
-- [Whalebird](https://github.com/h3poteto/whalebird-desktop): An Electron-based Mastodon, Pleroma and Misskey client for Windows, Mac and Linux
+- [Hyperspace](https://github.com/hyperspacedev/hyperspace): cross-platform Mastodon client for the fediverse written in TypeScript and React. (Archived - Nov 9, 2022)
 
 - [Sengi](https://github.com/NicolasConstant/sengi): cross-platform multi-account Mastodon & Pleroma desktop client
 
@@ -470,19 +490,29 @@ Overview of open-source alternative for popular applications.
 
 - [Tootle](https://github.com/bleakgrey/tootle): simple GTK-based Linux Mastodon client. (Archived - Nov 9, 2022)
 
+- [Whalebird](https://github.com/h3poteto/whalebird-desktop): An Electron-based Mastodon, Pleroma and Misskey client for Windows, Mac and Linux
+
+- [Tokodon](https://github.com/KDE/tokodon): A Mastodon client for Plasma and Plasma Mobile
+
+#### Web
+
+- [Pinafore](https://github.com/nolanlawson/pinafore): Alternative web client for Mastodon, focused on speed and simplicity
+
+- [Cuckoo+](https://github.com/NanaMorse/Cuckoo.Plus): A GooglePlus-Like third-party web client for mastodon.
+
+#### Mobile
+
 - [Tusky](https://github.com/tuskyapp/Tusky): lightweight Android Mastodon client
 
 - [SubwayTooter](https://github.com/tateisu/SubwayTooter): A Mastodon client app for Android phone/tablet.
 
-- [Tokodon](https://github.com/KDE/tokodon): A Mastodon client for Plasma and Plasma Mobile
-
 - [Fedilab](https://framagit.org/tom79/fedilab): multi-account Android Mastodon client. (Archived)
-
-- [Hyperspace](https://github.com/hyperspacedev/hyperspace): cross-platform Mastodon client for the fediverse written in TypeScript and React. (Archived - Nov 9, 2022)
 
 - [Metatext](https://github.com/metabolist/metatext): A free, open-source iOS Mastodon client. (Archived - Dec 1, 2022)
 
 ### Telegram
+
+#### Mobile
 
 - [Telegram-FOSS](https://github.com/Telegram-FOSS-Team/Telegram-FOSS): Unofficial, FOSS-friendly fork of the original Telegram client for Android
 
@@ -494,22 +524,32 @@ Overview of open-source alternative for popular applications.
 
 ### CCleaner
 
+#### Desktop
+
 - [Bleachbit](https://github.com/bleachbit/bleachbit): An open-source system cleaner for Windows and Linux.
   - Official website: https://www.bleachbit.org/
 
 ### LastPass
 
+#### Desktop
+
 - [Bitwarden](https://bitwarden.com/): A free/freemium open-source password manager that stores sensitive information such as website credentials in an encrypted vault. Can be self-hosted.
-  - Mobile app repository: https://github.com/bitwarden/mobile
   - Browser/Desktop app repository: https://github.com/bitwarden/clients
 
  - [KeepassXC](https://github.com/keepassxreboot/keepassxc): A modern, cross-platform, secure, and open-source password manager. Requires no internet connection.
 
- - [Keepass2Android](https://github.com/PhilippC/keepass2android): A Password manager app for Android. Requires no internet connection.
-
  - [vaultwarden](https://github.com/dani-garcia/vaultwarden): Password manager. Unofficial Bitwarden compatible server written in Rust, formerly known as bitwarden_rs
 
+ #### Mobile
+
+ - [Bitwarden](https://bitwarden.com/): A free/freemium open-source password manager that stores sensitive information such as website credentials in an encrypted vault. Can be self-hosted.
+  - Mobile app repository: https://github.com/bitwarden/mobile
+
+ - [Keepass2Android](https://github.com/PhilippC/keepass2android): A Password manager app for Android. Requires no internet connection.
+
 ### Nova Launcher
+
+#### Mobile
 
 - [Neo Launcher](https://github.com/NeoApplications/Neo-Launcher): A fork of AOSP's launcher for power-users.
 
@@ -519,15 +559,21 @@ Overview of open-source alternative for popular applications.
 
 ### Medium
 
+#### Web
+
 - [Scribe](https://sr.ht/~edwardloveall/Scribe): Alternative front-end to Medium.com
   - Official website: https://scribe.rip
 
 ### Reuters
 
+#### Web
+
 - [Neuters](https://github.com/HookedBehemoth/neuters): An alternative front-end to Reuters.com. It is intented to be lightweight and fast, and was heavily inspired by Nitter
   - Official instance: https://neuters.de/
 
 ### Apple AirPlay
+
+#### Desktop
 
 - [RPiPlay](https://github.com/FD-/RPiPlay): An open-source AirPlay mirroring server for the Raspberry Pi. Supports iOS 9 and up.
 
@@ -535,16 +581,24 @@ Overview of open-source alternative for popular applications.
 
 ### Shazam
 
+#### Desktop
+
 - [SongRec](https://github.com/marin-m/SongRec): Open-source Shazam client for Linux, written in Rust
 
 ### Adobe Reader
 
+#### Desktop
+
 - [SumatraPDF](https://github.com/sumatrapdfreader/sumatrapdf): A free and open-source document viewer for Windows that supports many document formats including: PDF, eBook (epub, mobi), comic book (cbz/cbr), DjVu, XPS, and CHM.
+
+#### Mobile
 
 - [MuPDF](https://mupdf.com/releases/index.html): A lightweight PDF, XPS, and E-book viewer. Cross-platform.
   - Official website: https://mupdf.com/
 
 ### Quora
+
+#### Web
 
 - [quetre](https://github.com/zyachel/quetre): A libre front-end for Quora
   - Official instance: https://quetre.iket.me
@@ -552,11 +606,15 @@ Overview of open-source alternative for popular applications.
 
 ## Pastebin
 
+#### Web
+
 - [NoPaste](https://github.com/bokub/nopaste): NoPaste is an open-source website similar to Pastebin where you can store any piece of code, and generate links for easy sharing
 
 - [PrivateBin](https://github.com/PrivateBin/PrivateBin): Zero knowledge encrypted paste-bin. A minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted in the browser using 256 bits AES
 
 ### Hacker News
+
+#### Web
 
 - [HN-search](https://github.com/algolia/hn-search): Algolia Hacker News search
   - Example: [Highest rated submissions of the past 24 hours](https://hn.algolia.com/?sort=byPopularity&page=0&dateRange=last24h&type=all)
@@ -569,6 +627,8 @@ Overview of open-source alternative for popular applications.
 
 - [Hckrnws](https://github.com/rajatkulkarni95/hckrnws): A custom front-end for a better reading experience of HackerNews
   - Official instance: https://www.hckrnws.com
+
+#### Mobile
 
 - [Hackers](https://github.com/weiran/Hackers): a native iOS app for Hacker News
   - Available to download on the Apple AppStore: https://apps.apple.com/us/app/hackers-for-hacker-news/id603503901

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Open-source alternatives
-Overview of alternative open source front-ends for popular internet platforms (e.g. YouTube, Twitter, etc.)
+Overview of open-source alternative for popular applications.
 
 ## Contents
 - [YouTube](#youtube)
@@ -17,17 +17,21 @@ Overview of alternative open source front-ends for popular internet platforms (e
 - [Google Translate](#google-translate)
 - [Google Play Store](#google-play-store)
 - [Google Authenticator](#google-authenticator)
+- [Google Maps](#google-maps)
 - [Gmail](#gmail)
+- [Gboard](#gboard)
 - [Facebook](#facebook)
 - [Facebook Messenger](#facebook-messenger)
 - [Mastodon](#mastodon)
+- [Telegram](#telegram)
+- [CCleaner](#ccleaner)
 - [LastPass](#lastpass)
+- [Nova Launcher](#nova-launcher)
 - [Medium](#medium)
 - [Reuters](#reuters)
 - [Apple AirPlay](#apple-airplay)
 - [Shazam](#shazam)
 - [Hacker News](#hacker-news)
-- [Telegram](#telegram)
 - [Quora](#quora)
 - [Other services](#other-services)
 - [Redirection](#redirection)
@@ -349,6 +353,14 @@ Overview of alternative open source front-ends for popular internet platforms (e
 
 - [Authenticator Pro](https://github.com/jamie-mh/AuthenticatorPro): Two-Factor Authentication (2FA) client for Android + Wear OS
 
+### Google Maps
+
+- [OpenStreetMap](https://www.openstreetmap.org/): built by a community of mappers that contribute and maintain data about roads, trails, cafés, railway stations, and much more, all over the world.
+
+- [StreetComplete](https://github.com/streetcomplete/StreetComplete): Easy to use OpenStreetMap editor for Android.
+
+- [OsmAnd](https://github.com/osmandapp/OsmAnd): A map and navigation application with access to the free, worldwide, and high-quality OpenStreetMap (OSM) database.
+
 ### Gmail
 
 - [Thunderbird](https://www.thunderbird.net/en-US/): A free open-source cross-platform email client.
@@ -356,6 +368,14 @@ Overview of alternative open source front-ends for popular internet platforms (e
 - [FairEmail](https://github.com/M66B/FairEmail): Fully featured, open source, privacy friendly email app for Android
 
 - [K-9 Mail](https://github.com/thundernest/k-9): an open-source email client for Android
+
+### Gboard
+
+- [OpenBoard](https://github.com/openboard-team/openboard): 100% FOSS keyboard based on AOSP, with no dependency on Google binaries, that respects your privacy.
+
+- [FlorisBoard](https://github.com/florisboard/florisboard): A free and open-source keyboard for Android 7.0+ devices. It aims at being modern, user-friendly and customizable while fully respecting your privacy. Currently in early-beta state.
+
+- [Simple Keyboard](https://github.com/rkkr/simple-keyboard): This keyboard is created for those who only need a keyboard and nothing more. No emoji, GIFs, Swipe typing, Spell checker. <1MB size.
 
 ### Facebook
 
@@ -391,15 +411,38 @@ Overview of alternative open source front-ends for popular internet platforms (e
 
 - [Metatext](https://github.com/metabolist/metatext): A free, open-source iOS Mastodon client. (Archived - Dec 1, 2022)
 
+### Telegram
+
+- [Telegram-FOSS](https://github.com/Telegram-FOSS-Team/Telegram-FOSS): Unofficial, FOSS-friendly fork of the original Telegram client for Android
+
+- [Forkgram](https://github.com/Forkgram/TelegramAndroid): A fork of the official Telegram for Android application.
+
+- [Nekogram](https://gitlab.com/Nekogram/Nekogram): An open-source third-party Telegram client with not many but useful mods.
+
+- [NekoX](https://github.com/NekoX-Dev/NekoX): A free and open source third-party Telegram client, based on Telegram-FOSS with features added (including from Nekogram).
+
+### CCleaner
+
+- [Bleachbit](https://github.com/bleachbit/bleachbit): An open-source system cleaner for Windows and Linux.
+  - Official website: https://www.bleachbit.org/
+
 ### LastPass
 
-- [Bitwarden](https://bitwarden.com/): a free/freemium open-source password manager that stores sensitive information such as website credentials in an encrypted vault. Can be self-hosted.
+- [Bitwarden](https://bitwarden.com/): A free/freemium open-source password manager that stores sensitive information such as website credentials in an encrypted vault. Can be self-hosted.
   - Mobile app repository: https://github.com/bitwarden/mobile
   - Browser/Desktop app repository: https://github.com/bitwarden/clients
 
- - [KeepassXC](https://github.com/keepassxreboot/keepassxc): a modern, cross-platform, secure, and open-source password manager. Requires no internet connection.
+ - [KeepassXC](https://github.com/keepassxreboot/keepassxc): A modern, cross-platform, secure, and open-source password manager. Requires no internet connection.
 
- - [Keepass2Android](https://github.com/PhilippC/keepass2android): a Password manager app for Android. Requires no internet connection.
+ - [Keepass2Android](https://github.com/PhilippC/keepass2android): A Password manager app for Android. Requires no internet connection.
+
+### Nova Launcher
+
+- [Neo Launcher](https://github.com/NeoApplications/Neo-Launcher): A fork of AOSP's launcher for power-users.
+
+- [Lawnchair](https://github.com/LawnchairLauncher/lawnchair): A free, open-source home app for Android. It ports Pixel Launcher features and introduces rich options for customization.
+
+- [KISS Launcher](https://github.com/Neamar/KISS): Blazingly fast launcher focused on search. 
 
 ### Medium
 
@@ -421,15 +464,12 @@ Overview of alternative open source front-ends for popular internet platforms (e
 
 - [SongRec](https://github.com/marin-m/SongRec): Open-source Shazam client for Linux, written in Rust
 
-### Telegram
+### Adobe Reader
 
-- [Telegram-FOSS](https://github.com/Telegram-FOSS-Team/Telegram-FOSS): Unofficial, FOSS-friendly fork of the original Telegram client for Android
+- [SumatraPDF](https://github.com/sumatrapdfreader/sumatrapdf): A free and open-source document viewer for Windows that supports many document formats including: PDF, eBook (epub, mobi), comic book (cbz/cbr), DjVu, XPS, and CHM.
 
-- [Forkgram](https://github.com/Forkgram/TelegramAndroid): A fork of the official Telegram for Android application.
-
-- [Nekogram](https://gitlab.com/Nekogram/Nekogram): An open-source third-party Telegram client with not many but useful mods.
-
-- [NekoX](https://github.com/NekoX-Dev/NekoX): A free and open source third-party Telegram client, based on Telegram-FOSS with features added (including from Nekogram).
+- [MuPDF](https://mupdf.com/releases/index.html): A lightweight PDF, XPS, and E-book viewer. Cross-platform.
+  - Official website: https://mupdf.com/
 
 ### Quora
 
@@ -498,14 +538,13 @@ Overview of alternative open source front-ends for popular internet platforms (e
   - [Firefox Add-On: uBlock Origin](https://addons.mozilla.org/en-US/firefox/addon/ublock-origin)
   - [Chrome Extension: uBlock Origin](https://chrome.google.com/webstore/detail/ublock-origin/cjpalhdlnbpafiamejdnhcphjbkeiagm)
 
-- [StreetComplete](https://github.com/streetcomplete/StreetComplete): Easy to use OpenStreetMap editor for Android
-
 - [Matrix.org's Synapse](https://github.com/matrix-org/synapse): End-to-end-encrypted messaging. Matrix reference homeserver. See also [matrix.org](https://matrix.org).
 
 - [Pluja's Awesome Privacy](https://github.com/pluja/awesome-privacy): A curated list of services and alternatives that respect your privacy because privacy matters.
 
-- [12ft.io / 12ft Ladder](https://12ft.io): 12ft Ladder is a free service for reading news articles. Prepend 12ft.io/ to the URL of any paywalled page, and we'll try our best to remove the paywall and get you access to the article. It is similar to Outline.com which is not available anymore.
-  - Note: The source code of 12ft Ladder is not available under a free/open-source license.
+- [Bypass Paywalls](https://github.com/iamadamdev/bypass-paywalls-chrome): A web browser extension to help bypass paywalls for selected sites.
+  - Firefox Add-on: https://github.com/iamadamdev/bypass-paywalls-chrome/releases/latest/download/bypass-paywalls-firefox.xpi
+  - Chromium-based Extension: https://github.com/iamadamdev/bypass-paywalls-chrome/archive/master.zip 
 
 - [Revanced](https://github.com/revanced): A collection of patches for different applications like Youtube, Twitter, and Reddit.
   - Revanced Manager: https://github.com/revanced/revanced-manager
@@ -513,12 +552,14 @@ Overview of alternative open source front-ends for popular internet platforms (e
 
 ## Call to Action
 - Do you know any other **free/open-source** projects that are not included in the overview yet? (front ends, alternatives to websites, apps, etc.)
-- Just create an issue [here](https://github.com/mendel5/alternative-front-ends/issues) and let me know. I'm always looking for new free/open-source projects to add.
+- Just create an issue [here](https://github.com/takomine/Open-source-alternatives/issues) or in the [original repo](https://github.com/mendel5/alternative-front-ends/issues) and let me know. I'm always looking for new free/open-source projects to add.
 
 ## About this repository
 
-This overview originally included three alternative front-ends: Invidious (for YouTube), Bibliogram (for Instagram) and Nitter (for Twitter). Therefore it was named `alternative front-ends`. As more projects have been added to the repository, the listed projects partially left the scope of *alternative front-ends*.
+**This is a fork of [alternative-front-ends](https://github.com/mendel5/alternative-front-ends). In my opinion, the scope of the original repo has already diverted from just being a catalog of alternative front-ends. This list tries to incorporate not just alternative front-ends but also an alternative open-source application.**
 
-For example, `youtube-dl` is not a front-end, but can be generally described as an open source project that interacts with the internet platform Youtube.
+>This overview originally included three alternative front-ends: Invidious (for YouTube), Bibliogram (for Instagram) and Nitter (for Twitter). Therefore it was named `alternative front-ends`. As more projects have been added to the repository, the listed projects partially left the scope of *alternative front-ends*.
 
-Therefore the name `alternative front-ends` does not capture the full scope of the listed projects anymore. Maybe this repository will be renamed in the future to better reflect the larger scope. A possible name might be `open-source-alternatives` or something similar.
+>For example, `youtube-dl` is not a front-end, but can be generally described as an open source project that interacts with the internet platform Youtube.
+
+>Therefore the name `alternative front-ends` does not capture the full scope of the listed projects anymore. Maybe this repository will be renamed in the future to better reflect the larger scope. A possible name might be `open-source-alternatives` or something similar.

--- a/README.md
+++ b/README.md
@@ -182,6 +182,9 @@ Overview of open-source alternative for popular applications.
 
 - [Fritter](https://github.com/jonjomckay/fritter): A free, open-source Twitter client for Android
 
+- [Dabr](https://github.com/DavidCarrington/dabr): a PHP web interface to the Twitter API for mobile devices.
+  - Website: https://dabr.co.uk/
+  - This is not a native application. It needs to be opened in a browser. Suitable for old devices like Symbian phones and old Android devices
 ### Reddit
 
 #### Web
@@ -517,6 +520,10 @@ Overview of open-source alternative for popular applications.
 - [Metatext](https://github.com/metabolist/metatext): A free, open-source iOS Mastodon client. (Archived - Dec 1, 2022)
 
 ### Telegram
+
+#### Web
+
+- [MPGram Web](https://github.com/shinovon/mpgram-web): A lightweight telegram web client based on MadelineProto
 
 #### Mobile
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-# Open-source alternatives
 Overview of open-source alternative for popular applications.
 
 ## Contents
@@ -6,7 +5,6 @@ Overview of open-source alternative for popular applications.
 - [YouTube Music](#youtube-music)
 - [Twitter](#twitter)
 - [Reddit](#reddit)
-- [Instagram](#instagram)
 - [TikTok](#tiktok)
 - [Imgur](#imgur)
 - [Spotify](#spotify)

--- a/README.md
+++ b/README.md
@@ -286,8 +286,6 @@ Overview of open-source alternative for popular applications.
 
 - [Spicetify](https://github.com/spicetify/spicetify-cli): Command-line tool to customize the official Spotify client. Supports Windows, MacOS and Linux.
 
-
-
 #### Mobile
 
 - [Spotube](https://github.com/KRTirtho/spotube): a Flutter based lightweight spotify client. It utilizes the power of Spotify & Youtube's public API & creates a hazardless, performant & resource friendly User Experience
@@ -546,6 +544,13 @@ Overview of open-source alternative for popular applications.
 - [Nekogram](https://gitlab.com/Nekogram/Nekogram): An open-source third-party Telegram client with not many but useful mods.
 
 - [NekoX](https://github.com/NekoX-Dev/NekoX): A free and open source third-party Telegram client, based on Telegram-FOSS with features added (including from Nekogram).
+
+- [Nagram](https://github.com/NextAlone/Nagram): A third-party Telegram client based on NekoX with some modifications. 
+
+- [Nullgram](https://github.com/qwq233/Nullgram): A free and open source third-party Telegram client, based on Telegram, NekoX and Nekogram.
+
+- [Owlgram](https://github.com/OwlGramDev/OwlGram): An unofficial messaging app that uses Telegram's API.
+  - Website: https://www.owlgram.org/
 
 ### Signal
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# alternative-front-ends
+# Open-source alternatives
 Overview of alternative open source front-ends for popular internet platforms (e.g. YouTube, Twitter, etc.)
 
 ## Contents
@@ -15,9 +15,13 @@ Overview of alternative open source front-ends for popular internet platforms (e
 - [Discord](#discord)
 - [Google Search](#google-search)
 - [Google Translate](#google-translate)
+- [Google Play Store](#google-play-store)
+- [Google Authenticator](#google-authenticator)
+- [Gmail](#gmail)
 - [Facebook](#facebook)
 - [Facebook Messenger](#facebook-messenger)
 - [Mastodon](#mastodon)
+- [LastPass](#lastpass)
 - [Medium](#medium)
 - [Reuters](#reuters)
 - [Apple AirPlay](#apple-airplay)
@@ -330,6 +334,29 @@ Overview of alternative open source front-ends for popular internet platforms (e
 
 - [Crow Translate](https://github.com/crow-translate/crow-translate): Simple and lightweight cross-platform translator that allows translation using LibreTranslate, Lingva, Google, Bing, and Yandex, as well as text-to-speech using Google
 
+### Google Play Store
+
+- [Aurora Store](https://gitlab.com/AuroraOSS/AuroraStore): An Open Source alternative for Google Play Store
+
+- [F-droid](https://f-droid.org/): An installable catalogue of FOSS (Free and Open Source Software) applications for the Android platform.
+  - It's not a direct alternative as it only has applications that are open source which may or may not be present in the Play store.
+
+- [Neo Store](https://github.com/NeoApplications/Neo-Store): An F-Droid client with modern UI and an arsenal of extra features. 
+
+### Google Authenticator
+
+- [Aegis](https://github.com/beemdevelopment/Aegis): A free, secure and open source app for Android to manage your 2-step verification tokens.
+
+- [Authenticator Pro](https://github.com/jamie-mh/AuthenticatorPro): Two-Factor Authentication (2FA) client for Android + Wear OS
+
+### Gmail
+
+- [Thunderbird](https://www.thunderbird.net/en-US/): A free open-source cross-platform email client.
+
+- [FairEmail](https://github.com/M66B/FairEmail): Fully featured, open source, privacy friendly email app for Android
+
+- [K-9 Mail](https://github.com/thundernest/k-9): an open-source email client for Android
+
 ### Facebook
 
 - [Frost](https://github.com/AllanWang/Frost-for-Facebook): An extensive and functional third party app for Facebook (Android app)
@@ -363,6 +390,16 @@ Overview of alternative open source front-ends for popular internet platforms (e
 - [Hyperspace](https://github.com/hyperspacedev/hyperspace): cross-platform Mastodon client for the fediverse written in TypeScript and React. (Archived - Nov 9, 2022)
 
 - [Metatext](https://github.com/metabolist/metatext): A free, open-source iOS Mastodon client. (Archived - Dec 1, 2022)
+
+### LastPass
+
+- [Bitwarden](https://bitwarden.com/): a free/freemium open-source password manager that stores sensitive information such as website credentials in an encrypted vault. Can be self-hosted.
+  - Mobile app repository: https://github.com/bitwarden/mobile
+  - Browser/Desktop app repository: https://github.com/bitwarden/clients
+
+ - [KeepassXC](https://github.com/keepassxreboot/keepassxc): a modern, cross-platform, secure, and open-source password manager. Requires no internet connection.
+
+ - [Keepass2Android](https://github.com/PhilippC/keepass2android): a Password manager app for Android. Requires no internet connection.
 
 ### Medium
 
@@ -470,11 +507,9 @@ Overview of alternative open source front-ends for popular internet platforms (e
 - [12ft.io / 12ft Ladder](https://12ft.io): 12ft Ladder is a free service for reading news articles. Prepend 12ft.io/ to the URL of any paywalled page, and we'll try our best to remove the paywall and get you access to the article. It is similar to Outline.com which is not available anymore.
   - Note: The source code of 12ft Ladder is not available under a free/open-source license.
 
-- [Youtube Vanced](https://github.com/YTVanced): Youtube replacement app for the Android platform: YouTube Vanced is the stock Android YouTube app, but better. It includes adblocking, true amoled dark mode and a lot more. Use the Vanced Manager to install YouTube Vanced with ease.
-  - Official website with install instructions: https://vancedapp.com
-  - Note: The source code of Youtube Vanced is not available under a free/open-source license.
-  - For an explanation about the origin of Youtube Vanced see here: https://old.reddit.com/r/Vanced/comments/o3xm9m/if_youtube_vanced_isnt_open_source_and_doesnt/h2ec7wf/
-  - Vanced was forced to shut down by Google due to legal reasons. The project https://github.com/ReVancedTeam tries to continue its legacy
+- [Revanced](https://github.com/revanced): A collection of patches for different applications like Youtube, Twitter, and Reddit.
+  - Revanced Manager: https://github.com/revanced/revanced-manager
+  - List of supported applications: https://github.com/revanced/revanced-patches  
 
 ## Call to Action
 - Do you know any other **free/open-source** projects that are not included in the overview yet? (front ends, alternatives to websites, apps, etc.)

--- a/README.md
+++ b/README.md
@@ -534,6 +534,7 @@ Overview of open-source alternative for popular applications.
 #### Web
 
 - [MPGram Web](https://github.com/shinovon/mpgram-web): A lightweight telegram web client based on MadelineProto
+  - Official Instance: https://mp.nnchan.ru/
 
 #### Mobile
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Overview of alternative open source front-ends for popular internet platforms (e
 
 - [NewPipe](https://github.com/TeamNewPipe/NewPipe): A libre lightweight streaming front-end for Android
 
+- [NewPipe with SponsorBlock & Return YouTube Dislike](https://github.com/polymorphicshade/NewPipe): A fork of NewPipe with SponsorBlock and Return YouTube Dislike functionality.
+
 - [Youtube-dl](https://github.com/ytdl-org/youtube-dl): Command-line program to download videos from YouTube.com and other video sites
 
 - [OpenVideoDownloader aka jely2002/youtube-dl-gui](https://github.com/jely2002/youtube-dl-gui): A cross-platform GUI for youtube-dl made in Electron and node.js
@@ -121,9 +123,11 @@ Overview of alternative open source front-ends for popular internet platforms (e
 
 - [LibreTube](https://github.com/libre-tube/LibreTube): Android frontend for YouTube, based on Piped
 
-- [BlackHole](https://github.com/Sangwan5688/BlackHole): Android music player app for YouTube Music and Spotify made with Flutter
-
 - [oleksis/youtube-dl-gui](https://github.com/oleksis/youtube-dl-gui): Cross-platform front-end GUI of the popular youtube-dl written in wxPython
+
+- [VueTube](https://github.com/VueTubeApp/VueTube): A simple and open source video streaming client aimed to recreate ALL the features from their respective apps. Built on Vue
+
+- [Hyperion](https://github.com/zt64/Hyperion): A modern alternate YouTube front-end for Android
 
 ### YouTube Music
 
@@ -134,6 +138,12 @@ Overview of alternative open source front-ends for popular internet platforms (e
 - [AudioTube](https://invent.kde.org/plasma-mobile/audiotube): Client for YouTube Music. Plasma-mobile project with an interface designed for Linux phones
 
 - [th-ch/youtube-music](https://github.com/th-ch/youtube-music): YouTube Music desktop app based on Electron bundled with custom plugins (including built-in ad blocker and downloader)
+
+- [BlackHole](https://github.com/Sangwan5688/BlackHole): Android music player app for YouTube Music and Spotify made with Flutter
+
+- [ViMusic](https://github.com/vfsfitvnm/ViMusic): An Android application for streaming music from YouTube Music
+
+- [InnerTune](https://github.com/z-huang/InnerTune): A material design YouTube Music client for Android
 
 ### Twitter
 
@@ -226,7 +236,7 @@ Overview of alternative open source front-ends for popular internet platforms (e
 
 ### Imgur
 
-- [Rimgo](https://codeberg.org/video-prize-ranch/rimgo): Self-hosted frontend for Imgur ritten in Go
+- [Rimgo](https://codeberg.org/video-prize-ranch/rimgo): Self-hosted frontend for Imgur written in Go
   - Website: https://i.bcow.xyz/
 
 - [Rimgu](https://codeberg.org/3np/rimgu): Self-hosted alternative frontend/ proxy for Imgur
@@ -265,6 +275,10 @@ Overview of alternative open source front-ends for popular internet platforms (e
 
 - [oggify](https://github.com/pisto/oggify): Download Spotify tracks to Ogg Vorbis (with a Spotify premium account), based on librespot
 
+- [Spotube](https://github.com/KRTirtho/spotube): a Flutter based lightweight spotify client. It utilizes the power of Spotify & Youtube's public API & creates a hazardless, performant & resource friendly User Experience
+
+- [xManager](https://github.com/xManager-v2/xManager-Spotify): An android application where you can manage and install all versions of the spotify app.
+
 ### Apple Music
 
 - [Cider](https://github.com/ciderapp/Cider): Cross-platform Apple Music experience based on Electron and Vue.js written from scratch with performance in mind
@@ -279,9 +293,33 @@ Overview of alternative open source front-ends for popular internet platforms (e
 
 - [ElectronPlayer](https://github.com/oscartbeaumont/ElectronPlayer): Electron Based Web Video Services Player. Supports Netflix, Youtube, Twitch, Floatplane, Hulu and more
 
+- [S0undTV](https://github.com/S0und/S0undTV): An alternative app to watch the Twitch streaming service for Android TV devices
+
 ### Discord
 
 - [gtkcord4](https://github.com/diamondburned/gtkcord4): A lightweight Discord client written in Golang which uses GTK3 for the user interface
+
+- [OpenCord](https://github.com/MateriiApps/OpenCord): An open-source Material You implementation of the Discord Android app
+
+- [Abaddon](https://github.com/uowuo/abaddon): An alternative Discord client made with C++/gtkmm
+
+- [Accord](https://github.com/evelyneee/accord): A discord client for modern macs
+
+- [Swiftcord](https://github.com/SwiftcordApp/Swiftcord): Native Discord client for macOS built in Swift
+ 
+- [Discordo](https://github.com/ayn2op/discordo): A lightweight, secure, and feature-rich Discord terminal client built with Go
+
+- [ChimeraCord](https://github.com/RoboChimera/ChimeraCord): A functional but elegant unofficial Discord client for freeBSD, that aims for feature-parity with the official Discord client.
+
+- [ArmCord](https://github.com/armcord/armcord): ArmCord is a custom client designed to enhance your Discord experience while keeping everything lightweight.
+
+- [datcord](https://github.com/gamingdoom/datcord): An open-source discord client using Firefox
+
+- [purpe-discord](https://github.com/EionRobb/purple-discord): A libpurple/Pidgin plugin for Discord
+
+- [Fosscord](https://github.com/fosscord/fosscord): A free open source selfhostable discord compatible chat, voice and video platform
+
+- [litecord](https://gitlab.com/litecord/litecord): An open source, clean-room design reimplementation of Discord's HTTP API and Gateway in Python 3
 
 ### Google Search
 
@@ -333,6 +371,10 @@ Overview of alternative open source front-ends for popular internet platforms (e
 
 - [Pinafore](https://github.com/nolanlawson/pinafore): Alternative web client for Mastodon, focused on speed and simplicity
 
+- [Cuckoo+](https://github.com/NanaMorse/Cuckoo.Plus): A GooglePlus-Like third-party web client for mastodon.
+
+- [Whalebird](https://github.com/h3poteto/whalebird-desktop): An Electron-based Mastodon, Pleroma and Misskey client for Windows, Mac and Linux
+
 - [Sengi](https://github.com/NicolasConstant/sengi): cross-platform multi-account Mastodon & Pleroma desktop client
 
 - [TheDesk](https://github.com/cutls/TheDesk): cross-platform Mastodon & Misskey desktop client
@@ -341,19 +383,25 @@ Overview of alternative open source front-ends for popular internet platforms (e
 
 - [Tusky](https://github.com/tuskyapp/Tusky): lightweight Android Mastodon client
 
+- [SubwayTooter](https://github.com/tateisu/SubwayTooter): A Mastodon client app for Android phone/tablet.
+
+- [Tokodon](https://github.com/KDE/tokodon): A Mastodon client for Plasma and Plasma Mobile
+
 - [Fedilab](https://framagit.org/tom79/fedilab): multi-account Android Mastodon client
 
 - [Hyperspace](https://github.com/hyperspacedev/hyperspace): cross-platform Mastodon client for the fediverse written in TypeScript and React
 
+- [Metatext](https://github.com/metabolist/metatext): A free, open-source iOS Mastodon client.
+
 ### Medium
 
-- [Scribe](https://sr.ht/~edwardloveall/scribe): Alternative front-end to Medium.com
+- [Scribe](https://sr.ht/~edwardloveall/Scribe): Alternative front-end to Medium.com
   - Official website: https://scribe.rip
 
 ### Reuters
 
 - [Neuters](https://github.com/HookedBehemoth/neuters): An alternative front-end to Reuters.com. It is intented to be lightweight and fast, and was heavily inspired by Nitter
-  - Official instance: https://boxcat.site
+  - Official instance: https://neuters.de/
 
 ### Apple AirPlay
 
@@ -368,6 +416,12 @@ Overview of alternative open source front-ends for popular internet platforms (e
 ### Telegram
 
 - [Telegram-FOSS](https://github.com/Telegram-FOSS-Team/Telegram-FOSS): Unofficial, FOSS-friendly fork of the original Telegram client for Android
+
+- [Forkgram](https://github.com/Forkgram/TelegramAndroid): A fork of the official Telegram for Android application.
+
+- [Nekogram](https://gitlab.com/Nekogram/Nekogram): An open-source third-party Telegram client with not many but useful mods.
+
+- [NekoX](https://github.com/NekoX-Dev/NekoX): A free and open source third-party Telegram client, based on Telegram-FOSS with features added (including from Nekogram).
 
 ### Hacker News
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Overview of alternative open source front-ends for popular internet platforms (e
 - [Shazam](#shazam)
 - [Hacker News](#hacker-news)
 - [Telegram](#telegram)
+- [Quora](#quora)
 - [Other services](#other-services)
 - [Redirection](#redirection)
 - [Related projects](#related-projects)
@@ -40,7 +41,7 @@ Overview of alternative open source front-ends for popular internet platforms (e
   - Installation guide for self-hosting: https://docs.invidious.io/Installation.md
 
 - [Piped](https://github.com/TeamPiped/Piped): An alternative privacy-friendly YouTube frontend which is efficient by design - Lightweight, no ads, no tracking
-  - Official instance: https://piped.kavin.rocks
+  - Official instance: https://piped.video/
   - List of public instances: https://github.com/TeamPiped/Piped/wiki/Instances
   - Installation guide for self-hosting: https://github.com/TeamPiped/Documentation/blob/main/content/docs/self-hosting/index.md
 
@@ -349,7 +350,7 @@ Overview of alternative open source front-ends for popular internet platforms (e
 
 - [TheDesk](https://github.com/cutls/TheDesk): cross-platform Mastodon & Misskey desktop client
 
-- [Tootle](https://github.com/bleakgrey/tootle): simple GTK-based Linux Mastodon client
+- [Tootle](https://github.com/bleakgrey/tootle): simple GTK-based Linux Mastodon client. (Archived - Nov 9, 2022)
 
 - [Tusky](https://github.com/tuskyapp/Tusky): lightweight Android Mastodon client
 
@@ -357,11 +358,11 @@ Overview of alternative open source front-ends for popular internet platforms (e
 
 - [Tokodon](https://github.com/KDE/tokodon): A Mastodon client for Plasma and Plasma Mobile
 
-- [Fedilab](https://framagit.org/tom79/fedilab): multi-account Android Mastodon client
+- [Fedilab](https://framagit.org/tom79/fedilab): multi-account Android Mastodon client. (Archived)
 
-- [Hyperspace](https://github.com/hyperspacedev/hyperspace): cross-platform Mastodon client for the fediverse written in TypeScript and React
+- [Hyperspace](https://github.com/hyperspacedev/hyperspace): cross-platform Mastodon client for the fediverse written in TypeScript and React. (Archived - Nov 9, 2022)
 
-- [Metatext](https://github.com/metabolist/metatext): A free, open-source iOS Mastodon client. (Archived as of Dec 1, 2022. Looking for mainteners. App still works)
+- [Metatext](https://github.com/metabolist/metatext): A free, open-source iOS Mastodon client. (Archived - Dec 1, 2022)
 
 ### Medium
 
@@ -392,6 +393,12 @@ Overview of alternative open source front-ends for popular internet platforms (e
 - [Nekogram](https://gitlab.com/Nekogram/Nekogram): An open-source third-party Telegram client with not many but useful mods.
 
 - [NekoX](https://github.com/NekoX-Dev/NekoX): A free and open source third-party Telegram client, based on Telegram-FOSS with features added (including from Nekogram).
+
+### Quora
+
+- [quetre](https://github.com/zyachel/quetre): A libre front-end for Quora
+  - Official instance: https://quetre.iket.me
+  - List of instances: https://github.com/zyachel/quetre#instances
 
 ### Hacker News
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # alternative-front-ends
 Overview of alternative open source front-ends for popular internet platforms (e.g. YouTube, Twitter, etc.)
 
-## Call to Action
-- Do you know any other **free/open-source** projects that are not included in the overview yet? (front ends, alternatives to websites, apps, etc.)
-- Just create an [issue](https://github.com/mendel5/alternative-front-ends/issues) and let me know. I'm always looking for new free/open-source projects to add.
-
 ## Contents
 - [YouTube](#youtube)
 - [YouTube Music](#youtube-music)
@@ -175,22 +171,14 @@ Overview of alternative open source front-ends for popular internet platforms (e
   - Example: /r/Privacy on [Reddit](https://www.reddit.com/r/privacy) and [Teddit](https://teddit.net/r/privacy)
 
 - [Libreddit](https://github.com/spikecodes/libreddit): Alternative front-end for Reddit. Themed around Reddit's new design - Lightweight, no JavaScript, no ads, no tracking
-  - Official instance: [libredd.it](https://libredd.it)
-  - Public instances: https://github.com/spikecodes/libreddit#instances
-
-- [Xeddit](https://github.com/ErlingMK/Xeddit): A Xamarin.Forms app for Reddit
-  - Official instance: [xeddit.com](https://www.xeddit.com)
-  - Example: /r/Privacy on [Reddit](https://www.reddit.com/r/privacy) and [Xeddit](https://www.xeddit.com/r/privacy)
+  - Official instance: https://libreddit.spike.codes/
+  - Public instances: https://github.com/libreddit/libreddit-instances/blob/master/instances.md
 
 - [RedditClient](https://github.com/grey-r/RedditSharp): Alternative front-end for Reddit, built with Angular
-
-- [Updoot](https://github.com/adityam49/Updoot): Android, alternative front-end for Reddit
 
 - [Eddrit](https://github.com/corenting/eddrit): Alternative front-end for Reddit, inspired by Nitter, built with Python & Starlette
 
 - [Top of Reddit](https://github.com/mgerb/top-of-reddit): Top Reddit posts every day
-
-- [Snew](https://github.com/snew/snew): Open-source client for Reddit forked from the Reddit source code
 
 - [Stealth](https://gitlab.com/cosmosapps/stealth): Account-free, privacy-oriented, and feature-rich Reddit client
   - Available on [F-Droid](https://f-droid.org/en/packages/com.cosmos.unreddit)
@@ -205,9 +193,6 @@ Overview of alternative open source front-ends for popular internet platforms (e
 - [Slide](https://github.com/ccrama/Slide): Open source, ad free Reddit browser for Android
   - Available on [F-Droid](https://f-droid.org/en/packages/me.ccrama.redditslide)
 
-- [junipf/reddit-frontend](https://github.com/junipf/reddit-frontend): A reddit front-end written in React
-  - Official instance: https://jpf-reddit.netlify.app
-  
 - [kddit](https://git.kalli.st/kallist/kddit-spaghetti): uWSGI frontend for Reddit.com written in Python
   - Official instance: https://kddit.kalli.st
   - `[Proxy]`
@@ -217,22 +202,11 @@ Overview of alternative open source front-ends for popular internet platforms (e
 
 - [Roffline](https://github.com/Darkle/Roffline): A self-hosted offline Reddit server. It allows you to browse Reddit posts (including any media in the post) while offline. It is targeted at people that have intermittent internet
 
-### Instagram
-
-- [Bibliogram](https://sr.ht/~cadence/bibliogram): Bibliogram is an alternative front-end for Instagram
-  - Unfortunately, Bibliogram is being discontinued. See https://cadence.moe/blog/2022-09-01-discontinuing-bibliogram
-  - Official instance: [https://bibliogram.art](https://bibliogram.art)
-  - Public instances: https://git.sr.ht/~cadence/bibliogram-docs/tree/master/docs/Instances.md
-  - Example: Troy Hunt on [Instagram](https://www.instagram.com/troyhunt) and [Bibliogram](https://bibliogram.art/u/troyhunt)
-
-- [Barinsta](https://github.com/austinhuang0131/barinsta): Open-source alternative Instagram client for Android
-  - On July 26, 2021, Austin Huang (maintainer of Barinsta) received a cease & desist letter from Perkins Coie LLP, a law firm representing Facebook. As a result, Barinsta is no longer maintained or distributed. More information can be found at https://github.com/mendel5/alternative-front-ends/issues/28 and https://austinhuang.me/barinsta .
-  - Fork of Barinsta: https://codeberg.org/avalos/barinsta - "This fork is unofficial unless community decides otherwise. C&D letters will be ignored."
-
 ### TikTok
 
 - [ProxiTok](https://github.com/pablouser1/ProxiTok): Open source alternative frontend for TikTok made with PHP
-  - Official instance: https://proxitok.herokuapp.com
+  - Official instance: https://proxitok.pabloferreiro.es/
+  - List of Public instances: https://github.com/pablouser1/ProxiTok/wiki/Public-instances
 
 ### Imgur
 
@@ -357,13 +331,9 @@ Overview of alternative open source front-ends for popular internet platforms (e
 
 ### Facebook
 
-- [SlimSocial](https://github.com/rignaneseleo/SlimSocial-for-Facebook): Android, alternative front-end for Facebook, built with Java
-
 - [Frost](https://github.com/AllanWang/Frost-for-Facebook): An extensive and functional third party app for Facebook (Android app)
 
 ### Facebook Messenger
-
-- [fb-messenger-cli](https://github.com/Alex-Rose/fb-messenger-cli): Use your Facebook account to chat with your friends sneakily in the command line, it's as easy as logging in, choosing a convo and chatting away
 
 - [Caprine](https://github.com/sindresorhus/caprine): Unofficial and privacy-focused Facebook Messenger app with many useful features
 
@@ -391,7 +361,7 @@ Overview of alternative open source front-ends for popular internet platforms (e
 
 - [Hyperspace](https://github.com/hyperspacedev/hyperspace): cross-platform Mastodon client for the fediverse written in TypeScript and React
 
-- [Metatext](https://github.com/metabolist/metatext): A free, open-source iOS Mastodon client.
+- [Metatext](https://github.com/metabolist/metatext): A free, open-source iOS Mastodon client. (Archived as of Dec 1, 2022. Looking for mainteners. App still works)
 
 ### Medium
 
@@ -498,6 +468,10 @@ Overview of alternative open source front-ends for popular internet platforms (e
   - Note: The source code of Youtube Vanced is not available under a free/open-source license.
   - For an explanation about the origin of Youtube Vanced see here: https://old.reddit.com/r/Vanced/comments/o3xm9m/if_youtube_vanced_isnt_open_source_and_doesnt/h2ec7wf/
   - Vanced was forced to shut down by Google due to legal reasons. The project https://github.com/ReVancedTeam tries to continue its legacy
+
+## Call to Action
+- Do you know any other **free/open-source** projects that are not included in the overview yet? (front ends, alternatives to websites, apps, etc.)
+- Just create an issue [here](https://github.com/mendel5/alternative-front-ends/issues) and let me know. I'm always looking for new free/open-source projects to add.
 
 ## About this repository
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Overview of open-source alternative for popular applications.
 - [Facebook Messenger](#facebook-messenger)
 - [Mastodon](#mastodon)
 - [Telegram](#telegram)
+- [Signal](#signal)
+- [Zoom](#zoom)
 - [CCleaner](#ccleaner)
 - [LastPass](#lastpass)
 - [Nova Launcher](#nova-launcher)
@@ -522,28 +524,51 @@ Overview of open-source alternative for popular applications.
 
 - [NekoX](https://github.com/NekoX-Dev/NekoX): A free and open source third-party Telegram client, based on Telegram-FOSS with features added (including from Nekogram).
 
+### Signal
+
+#### Mobile
+
+- [Molly](https://github.com/mollyim/mollyim-android): A hardened version of Signal for Android, the fast simple yet secure messaging app by Signal Foundation.
+  - Official Website: https://molly.im/
+
+- [Signal-JW](https://github.com/johanw666/Signal-Android): A Signal fork with extra options added.
+
+- [Langis](https://langis.cloudfrancois.fr/): Signal without Google Play Services support.
+  - Source code: [Latest artifact](https://git.legeox.net/capslock/signal-gcm-less/-/jobs/artifacts/master/download?job=upload_vt)
+
+### Zoom
+
+#### Cross-platform
+
+- [Jitsi Meet](https://github.com/jitsi/jitsi-meet): A set of Open Source projects which empower users to use and deploy video conferencing platforms with state-of-the-art video quality and features.
+  - Official Website: https://jitsi.org/jitsi-meet/
+
+- [Jami](https://git.jami.net/savoirfairelinux/jami-project): A free software for universal communication which respects freedoms and privacy of its users. P2P. Backed by GNU
+  - Official Website: https://jami.net/
+
 ### CCleaner
 
 #### Desktop
 
 - [Bleachbit](https://github.com/bleachbit/bleachbit): An open-source system cleaner for Windows and Linux.
-  - Official website: https://www.bleachbit.org/
+  - Official Website: https://www.bleachbit.org/
 
 ### LastPass
 
-#### Desktop
+#### Cross-platform
 
 - [Bitwarden](https://bitwarden.com/): A free/freemium open-source password manager that stores sensitive information such as website credentials in an encrypted vault. Can be self-hosted.
   - Browser/Desktop app repository: https://github.com/bitwarden/clients
+  - Mobile app repository: https://github.com/bitwarden/mobile
+
+#### Desktop
+
 
  - [KeepassXC](https://github.com/keepassxreboot/keepassxc): A modern, cross-platform, secure, and open-source password manager. Requires no internet connection.
 
  - [vaultwarden](https://github.com/dani-garcia/vaultwarden): Password manager. Unofficial Bitwarden compatible server written in Rust, formerly known as bitwarden_rs
 
  #### Mobile
-
- - [Bitwarden](https://bitwarden.com/): A free/freemium open-source password manager that stores sensitive information such as website credentials in an encrypted vault. Can be self-hosted.
-  - Mobile app repository: https://github.com/bitwarden/mobile
 
  - [Keepass2Android](https://github.com/PhilippC/keepass2android): A Password manager app for Android. Requires no internet connection.
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Overview of open-source alternative for popular applications.
 - [Apple Music](#apple-music)
 - [Twitch](#twitch)
 - [Discord](#discord)
+- [Google Chrome](#google-chrome)
 - [Google Search](#google-search)
 - [Google Translate](#google-translate)
 - [Google Play Store](#google-play-store)
@@ -135,13 +136,19 @@ Overview of open-source alternative for popular applications.
 
 ### YouTube Music
 
+#### Desktop
+
 - [ytmdesktop](https://github.com/ytmdesktop/ytmdesktop): Cross-platform (Windows, Mac, and Linux) desktop app for YouTube Music. Has a (proprietary?) remote control app for Android
+
+- [th-ch/youtube-music](https://github.com/th-ch/youtube-music): YouTube Music desktop app based on Electron bundled with custom plugins (including built-in ad blocker and downloader)
+
+#### Web
 
 - [Beatbump](https://github.com/snuffyDev/Beatbump): An alternative frontend for YouTube Music created using Svelte/SvelteKit, powered by Cloudflare Workers
 
-- [AudioTube](https://invent.kde.org/plasma-mobile/audiotube): Client for YouTube Music. Plasma-mobile project with an interface designed for Linux phones
+#### Mobile
 
-- [th-ch/youtube-music](https://github.com/th-ch/youtube-music): YouTube Music desktop app based on Electron bundled with custom plugins (including built-in ad blocker and downloader)
+- [AudioTube](https://invent.kde.org/plasma-mobile/audiotube): Client for YouTube Music. Plasma-mobile project with an interface designed for Linux phones
 
 - [BlackHole](https://github.com/Sangwan5688/BlackHole): Android music player app for YouTube Music and Spotify made with Flutter
 
@@ -151,10 +158,20 @@ Overview of open-source alternative for popular applications.
 
 ### Twitter
 
+#### Desktop
+
+- [Tweepy](https://github.com/tweepy/tweepy): Twitter for Python
+
+- [Tweeterr](https://github.com/sherwyn11/Tweeterr): A tool to use Twitter from the command line on the fly
+
+#### Web
+
 - [Nitter](https://github.com/zedeus/nitter): Alternative Twitter front-end - Lightweight, no ads, no tracking, no JavaScript required
   - Official instance: [nitter.net](https://nitter.net)
   - Public instances: https://github.com/zedeus/nitter/wiki/Instances
   - Example: Troy Hunt on [Twitter](https://twitter.com/troyhunt) and [Nitter](https://nitter.net/troyhunt)
+
+#### Mobile
 
 - [Shitter](https://github.com/nuclearfog/Shitter): Android, alternative front-end for Twitter, built with Java
 
@@ -162,15 +179,13 @@ Overview of open-source alternative for popular applications.
 
 - [Twidere X](https://github.com/TwidereProject/TwidereX-Android): Android, alternative front-end for Twitter, built mostly with Kotlin, in early stage
 
-- [Tweeterr](https://github.com/sherwyn11/Tweeterr): A tool to use Twitter from the command line on the fly
-
 - [Tweet-app](https://github.com/rhysd/tweet-app): Desktop Twitter client only for tweeting. Timeline never shows up
-
-- [Tweepy](https://github.com/tweepy/tweepy): Twitter for Python
 
 - [Fritter](https://github.com/jonjomckay/fritter): A free, open-source Twitter client for Android
 
 ### Reddit
+
+#### Web
 
 - [Teddit](https://codeberg.org/teddit/teddit): Alternative Reddit front-end focused on privacy - Lightweight, no ads, no JavaScript, unofficial API
   - Official instance: https://teddit.net
@@ -188,35 +203,37 @@ Overview of open-source alternative for popular applications.
 
 - [Top of Reddit](https://github.com/mgerb/top-of-reddit): Top Reddit posts every day
 
+- [kddit](https://git.kalli.st/kallist/kddit-spaghetti): uWSGI frontend for Reddit.com written in Python
+  - Official instance: https://kddit.kalli.st
+  - `[Proxy]`
+
+- [Roffline](https://github.com/Darkle/Roffline): A self-hosted offline Reddit server. It allows you to browse Reddit posts (including any media in the post) while offline. It is targeted at people that have intermittent internet
+
+#### Mobile
+
 - [Stealth](https://gitlab.com/cosmosapps/stealth): Account-free, privacy-oriented, and feature-rich Reddit client
   - Available on [F-Droid](https://f-droid.org/en/packages/com.cosmos.unreddit)
 
 - [Infinity](https://github.com/Docile-Alligator/Infinity-For-Reddit): Reddit client for Android
   - Available on [F-Droid](https://f-droid.org/en/packages/ml.docilealligator.infinityforreddit)
 
-- [Dawn](https://github.com/Tunous/Dawn): Open-source Reddit app
-  - Available on [F-Droid](https://f-droid.org/en/packages/me.thanel.dank)
-  - Forked from Dank: https://github.com/saket/Dank
-
 - [Slide](https://github.com/ccrama/Slide): Open source, ad free Reddit browser for Android
   - Available on [F-Droid](https://f-droid.org/en/packages/me.ccrama.redditslide)
-
-- [kddit](https://git.kalli.st/kallist/kddit-spaghetti): uWSGI frontend for Reddit.com written in Python
-  - Official instance: https://kddit.kalli.st
-  - `[Proxy]`
 
 - [Troddit](https://github.com/burhan-syed/troddit): A web client for Reddit
   - Official instance: https://www.troddit.com
 
-- [Roffline](https://github.com/Darkle/Roffline): A self-hosted offline Reddit server. It allows you to browse Reddit posts (including any media in the post) while offline. It is targeted at people that have intermittent internet
-
 ### TikTok
+
+#### Web
 
 - [ProxiTok](https://github.com/pablouser1/ProxiTok): Open source alternative frontend for TikTok made with PHP
   - Official instance: https://proxitok.pabloferreiro.es/
   - List of Public instances: https://github.com/pablouser1/ProxiTok/wiki/Public-instances
 
 ### Imgur
+
+#### Web
 
 - [Rimgo](https://codeberg.org/video-prize-ranch/rimgo): Self-hosted frontend for Imgur written in Go
   - Website: https://i.bcow.xyz/
@@ -239,7 +256,13 @@ Overview of open-source alternative for popular applications.
 - [imgrs](https://git.geraldwu.com/gerald/imgrs): Imgrs is a free and open-source alternative Imgur front-end focused on privacy. It's a Rust rewrite of a previous Imgur proxy project, Omgur.
   - Mirror of the original repository on Github: https://github.com/geraldwuhoo/imgrs
 
+#### Mobile
+
+- [ImgurViewer](https://github.com/SpartanJ/ImgurViewer): a little image viewer to open image links from external applications in the fastest way possible.
+
 ### Spotify
+
+#### Desktop
 
 - [psst](https://github.com/jpochyla/psst): Fast and multi-platform Spotify client with native GUI
 
@@ -257,31 +280,37 @@ Overview of open-source alternative for popular applications.
 
 - [oggify](https://github.com/pisto/oggify): Download Spotify tracks to Ogg Vorbis (with a Spotify premium account), based on librespot
 
+#### Mobile
+
 - [Spotube](https://github.com/KRTirtho/spotube): a Flutter based lightweight spotify client. It utilizes the power of Spotify & Youtube's public API & creates a hazardless, performant & resource friendly User Experience
 
 - [xManager](https://github.com/xManager-v2/xManager-Spotify): An android application where you can manage and install all versions of the spotify app.
 
 ### Apple Music
 
+#### Desktop
+
 - [Cider](https://github.com/ciderapp/Cider): Cross-platform Apple Music experience based on Electron and Vue.js written from scratch with performance in mind
 
 ### Twitch
 
+#### Desktop
+
 - [streamlink-twitch-gui](https://github.com/streamlink/streamlink-twitch-gui): Multi platform Twitch.tv browser for Streamlink
+
+#### Mobile
 
 - [Twire](https://github.com/twireapp/Twire): Alternative and open source Twitch client for Android
 
 - [Xtra](https://github.com/crackededed/Xtra): Twitch player and browser for Android
 
-- [ElectronPlayer](https://github.com/oscartbeaumont/ElectronPlayer): Electron Based Web Video Services Player. Supports Netflix, Youtube, Twitch, Floatplane, Hulu and more
-
 - [S0undTV](https://github.com/S0und/S0undTV): An alternative app to watch the Twitch streaming service for Android TV devices
 
 ### Discord
 
-- [gtkcord4](https://github.com/diamondburned/gtkcord4): A lightweight Discord client written in Golang which uses GTK3 for the user interface
+#### Desktop
 
-- [OpenCord](https://github.com/MateriiApps/OpenCord): An open-source Material You implementation of the Discord Android app
+- [gtkcord4](https://github.com/diamondburned/gtkcord4): A lightweight Discord client written in Golang which uses GTK3 for the user interface
 
 - [Abaddon](https://github.com/uowuo/abaddon): An alternative Discord client made with C++/gtkmm
 
@@ -303,7 +332,44 @@ Overview of open-source alternative for popular applications.
 
 - [litecord](https://gitlab.com/litecord/litecord): An open source, clean-room design reimplementation of Discord's HTTP API and Gateway in Python 3
 
+#### Mobile
+
+- [OpenCord](https://github.com/MateriiApps/OpenCord): An open-source Material You implementation of the Discord Android app
+
+### Google Chrome
+
+#### Desktop
+
+- [Firefox](https://www.mozilla.org/en-US/firefox/new/): A free and open-source web browser developed by the Mozilla Foundation
+  - Source repo: https://hg.mozilla.org/mozilla-central
+  - FTP Download: https://ftp.mozilla.org/pub/firefox/releases/
+
+- [Brave](https://github.com/brave/brave-browser): Secure, Fast & Private Web Browser with Adblocker
+  - Official website: https://brave.com/
+  - Download: https://brave.com/download/
+
+- [Librewolf](https://gitlab.com/librewolf-community): A Firefox fork with the primary goals of privacy, security and user freedom.
+  - Official website: https://librewolf.net/
+
+- [ungoogled-chromium](https://github.com/ungoogled-software/ungoogled-chromium): Google Chromium, sans integration with Google.
+
+- [Otter Browser](https://github.com/OtterBrowser/otter-browser): Aims to recreate the best aspects of the classic Opera (12.x) UI using Qt5.
+
+#### Mobile
+
+- [Fenix](https://github.com/mozilla-mobile/fenix): Firefox for Android
+  - Official Website: https://www.mozilla.org/en-US/firefox/browsers/mobile/
+  
+- [Brave](https://github.com/brave/brave-browser): A fast, free, secure web browser for your mobile devices.
+  - Download link for [Android](https://play.google.com/store/apps/details?id=com.brave.browser&hl=en) and [iOS](https://apps.apple.com/us/app/brave-private-web-browser/id1052879175?mt=8&ign-mpt=uo%3D4)
+
+- [Bromite](https://github.com/bromite/bromite): a Chromium fork with support for ad blocking and enhanced privacy.
+
+- [Mull](https://gitlab.com/divested-mobile/mull-fenix): A privacy oriented and deblobbed web browser based on Mozilla technology. It enables many features upstreamed by the Tor Uplift project using preferences from the arkenfox-user.js project. 
+ 
 ### Google Search
+
+#### Web
 
 - [Whoogle Search](https://github.com/benbusby/whoogle-search): A self-hosted, ad-free, privacy-respecting metasearch engine for Google
   - Public instances: https://github.com/benbusby/whoogle-search#public-instances
@@ -316,7 +382,13 @@ Overview of open-source alternative for popular applications.
 - [LibreX](https://github.com/hnhx/librex): Privacy respecting free meta search engine (free as in freedom)
   - Small and simple meta search engine, fetches and anonymizes results from Google only, has API support, allows redirects to Invidious/ Bibliogram/ Nitter/ Libreddit
 
+#### Mobile
+
+- [Gugal](https://gitlab.com/narektor/gugal): A clean, lightweight, FOSS web search app.
+
 ### Google Translate
+
+#### Web
 
 - [Lingva Translate](https://github.com/TheDavidDelta/lingva-translate): Alternative front-end for Google Translate, serving as a free and open-source translator with over a hundred languages available
   - Official instance: [lingva.ml](https://lingva.ml)

--- a/fork-changes.md
+++ b/fork-changes.md
@@ -56,6 +56,11 @@ added:
 * Fosscord
 * litecord
 
+## Twitter
+
+added:
+* Dabr
+
 ## Mastodon
 
 added:
@@ -90,6 +95,7 @@ added:
 * Forkgram
 * Nekogram
 * NekoX
+* MPGram
 
 ## Instagram
 

--- a/fork-changes.md
+++ b/fork-changes.md
@@ -1,5 +1,3 @@
-# All changes made from original repo
-
 ## Youtube
 
 added:
@@ -100,6 +98,9 @@ added:
 * Nekogram
 * NekoX
 * MPGram
+* Nagram
+* Nullgram
+* Owlgram
 
 ## Instagram
 

--- a/fork-changes.md
+++ b/fork-changes.md
@@ -1,3 +1,5 @@
+# All changes made from original repo
+
 ## Youtube
 
 added:

--- a/fork-changes.md
+++ b/fork-changes.md
@@ -24,12 +24,14 @@ added:
 * Blackhole
 * ViMusic
 * InnerTune
+* Brianify
 
 ## Spotify
 
 added:
 * Spotube
 * xManager
+* Spitify
 
 ## Twitch
 

--- a/fork-changes.md
+++ b/fork-changes.md
@@ -70,6 +70,7 @@ added:
 * SubwayTooter
 * Tokodon
 * Metatext (Archived)
+* Elk
 
 modified:
 * Tootle (Archived)

--- a/fork-changes.md
+++ b/fork-changes.md
@@ -71,6 +71,7 @@ added:
 * Tokodon
 * Metatext (Archived)
 * Elk
+* Brutaldon
 
 modified:
 * Tootle (Archived)

--- a/fork-changes.md
+++ b/fork-changes.md
@@ -1,0 +1,245 @@
+## Youtube
+
+added:
+* NewPipe x SponsorBlock x Return YouTube Dislike 
+* Vuetube
+* Hyperion
+
+modified:
+* Piped (updated Official instance)
+
+removed: 
+* Blackhole
+* Youtube.js
+* mps-youtube
+* ytdl-gui
+* Plumber
+* Tubesync
+* Invidious-viewer
+* TubeArchivist
+
+## Youtube Music
+
+added:
+* Blackhole
+* ViMusic
+* InnerTune
+
+## Spotify
+
+added:
+* Spotube
+* xManager
+
+## Twitch
+
+added:
+* S0undTV
+
+removed:
+* ElectronPlayer
+
+## Discord
+
+added:
+* Abaddon
+* OpenCord
+* Accord
+* Swiftcord
+* Discordo
+* ChimeraCord
+* ArmCord
+* datcord
+* purple-discord
+* Fosscord
+* litecord
+
+## Mastodon
+
+added:
+* Metatext
+* CuckooPlus
+* Whalebird
+* SubwayTooter
+* Tokodon
+* Metatext (Archived)
+
+modified:
+* Tootle (Archived)
+* Fedilab (Archived)
+* Hyperspace (Archived)
+
+modified:
+* Metatext (added Archive status)
+
+## Medium
+
+modified:
+* Scribe (update repo link)
+
+## Reuters
+
+modified:
+* Neuters (update instance link)
+
+## Telegram
+
+added:
+* Forkgram
+* Nekogram
+* NekoX
+
+## Instagram
+
+* Removed. Bibliogram and Barinsta (including its fork) has been archived and discontinued. Both do not work anymore.
+
+## Tiktok
+
+updated:
+* Proxitok (Official and public instances)
+
+## Facebook
+
+removed:
+* SlimSocial (Discontinued. Its dev wants to rewrite it in the future)
+
+## Facebook Messenger
+
+removed:
+* fb-messenger-cli (Abandoned. Last update: Aug 08, 2019)
+
+## Reddit
+
+modified:
+* Libreddit (updated Official/Public instances link)
+
+removed:
+* Updoot (Abandoned. Last update Dec 28, 2021)
+* Snew (Abandoned. Last update Aug 9, 2018)
+* reddit-frontend (Abandoned. Last update Mar 6, 2020)
+* Xeddit (Abandoned. Last update May 10, 2020)
+* Dawn (Abandoned. Last update Nov 21, 2021)
+
+## Google Search
+
+added:
+* Gugal
+
+## Google Translate
+
+added:
+* LibreTranslate
+
+## Others
+
+* added category based on platform (Desktop|Web|Mobile)
+* modified description
+* moved "Call to Action" at the end before "About this repository"
+* replaced Youtube Vanced with Revanced
+* replaced 12ft.io with Bypass 
+* removed Wikiless (source code page 404'd)
+
+# New additions
+
+## Quora
+
+added:
+* quetre
+
+## Google Play Store
+
+added:
+* Aurora Store
+* F-droid
+* Neo Store
+
+## Google Authenticator
+
+added:
+* Aegis
+* Authenticator Pro
+
+## Gmail
+
+added:
+* Thunderbird
+* FairEmail
+* F-9 Mail
+* Mailspring
+
+## LastPass
+
+added:
+* Bitwarden
+* vaultwarden
+* KeepassXC
+* Keepass2Android
+
+## CCleaner
+
+added:
+* Bleachbit
+
+## Google Maps
+
+added: 
+* OpenStreetMap
+* StreetComplete
+* OsmAnd
+
+## Gboard
+
+added:
+* OpenBoard
+* FlorisBoard
+* Simple Keyboard
+
+## Adobe Reader
+
+added:
+* SumatraPDF
+* MuPDF
+
+## Nova Launcher
+
+added:
+* Neo Launcher
+* Lawnchair
+* KISS Launcher
+
+## Pastebin
+
+added:
+* NoPaste
+* Privatebin
+
+## Imgur
+
+added:
+* ImgurViewer
+
+## Google Chrome
+
+added:
+* Firefox
+* Bravev
+* Librewolf
+* ungoogled-chromiuu
+* Otter Browser
+* Fenix
+* Brave
+* Bromite
+* Mull
+
+## Zoom
+
+added:
+* Jitsi Meet
+* Jami
+
+## Signal
+
+added:
+* Signal-JW
+* Langis
+* Molly


### PR DESCRIPTION
## Youtube

added:
* NewPipe x SponsorBlock x Return YouTube Dislike 
* Vuetube
* Hyperion

modified:
* Piped (updated Official instance)

removed: 
* Blackhole
* Youtube.js
* mps-youtube
* ytdl-gui
* Plumber
* Tubesync
* Invidious-viewer
* TubeArchivist

## Youtube Music

added:
* Blackhole
* ViMusic
* InnerTune
* Brianify

## Spotify

added:
* Spotube
* xManager
* Spitify

## Twitch

added:
* S0undTV

removed:
* ElectronPlayer

## Discord

added:
* Abaddon
* OpenCord
* Accord
* Swiftcord
* Discordo
* ChimeraCord
* ArmCord
* datcord
* purple-discord
* Fosscord
* litecord

## Twitter

added:
* Dabr

## Mastodon

added:
* Metatext
* CuckooPlus
* Whalebird
* SubwayTooter
* Tokodon
* Metatext (Archived)
* Elk
* Brutaldon

modified:
* Tootle (Archived)
* Fedilab (Archived)
* Hyperspace (Archived)

modified:
* Metatext (added Archive status)

## Medium

modified:
* Scribe (update repo link)

## Reuters

modified:
* Neuters (update instance link)

## Telegram

added:
* Forkgram
* Nekogram
* NekoX
* MPGram
* Nagram
* Nullgram
* Owlgram

## Instagram

* Removed. Bibliogram and Barinsta (including its fork) has been archived and discontinued. Both do not work anymore.

## Tiktok

updated:
* Proxitok (Official and public instances)

## Facebook

removed:
* SlimSocial (Discontinued. Its dev wants to rewrite it in the future)

## Facebook Messenger

removed:
* fb-messenger-cli (Abandoned. Last update: Aug 08, 2019)

## Reddit

modified:
* Libreddit (updated Official/Public instances link)

removed:
* Updoot (Abandoned. Last update Dec 28, 2021)
* Snew (Abandoned. Last update Aug 9, 2018)
* reddit-frontend (Abandoned. Last update Mar 6, 2020)
* Xeddit (Abandoned. Last update May 10, 2020)
* Dawn (Abandoned. Last update Nov 21, 2021)

## Google Search

added:
* Gugal

## Google Translate

added:
* LibreTranslate

## Others

* added category based on platform (Desktop|Web|Mobile)
* modified description
* moved "Call to Action" at the end before "About this repository"
* replaced Youtube Vanced with Revanced
* replaced 12ft.io with Bypass 
* removed Wikiless (source code page 404'd)

# New additions

## Quora

added:
* quetre

## Google Play Store

added:
* Aurora Store
* F-droid
* Neo Store

## Google Authenticator

added:
* Aegis
* Authenticator Pro

## Gmail

added:
* Thunderbird
* FairEmail
* F-9 Mail
* Mailspring

## LastPass

added:
* Bitwarden
* vaultwarden
* KeepassXC
* Keepass2Android

## CCleaner

added:
* Bleachbit

## Google Maps

added: 
* OpenStreetMap
* StreetComplete
* OsmAnd

## Gboard

added:
* OpenBoard
* FlorisBoard
* Simple Keyboard

## Adobe Reader

added:
* SumatraPDF
* MuPDF

## Nova Launcher

added:
* Neo Launcher
* Lawnchair
* KISS Launcher

## Pastebin

added:
* NoPaste
* Privatebin

## Imgur

added:
* ImgurViewer

## Google Chrome

added:
* Firefox
* Bravev
* Librewolf
* ungoogled-chromiuu
* Otter Browser
* Fenix
* Brave
* Bromite
* Mull

## Zoom

added:
* Jitsi Meet
* Jami

## Signal

added:
* Signal-JW
* Langis
* Molly